### PR TITLE
PNG-based display

### DIFF
--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -63,7 +63,7 @@ class GeoTrellis(object):
     def ingest(self, data, name, **kwargs):
         from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
         from geopyspark.geotrellis.render import PngRDD
-        from geopyspark.geotrellis.constants import ZOOM
+        # from geopyspark.geotrellis.constants import ZOOM
 
         rdd = data.rdd
         if isinstance(rdd, RasterRDD):
@@ -80,16 +80,17 @@ class GeoTrellis(object):
         else:
             raise Exception
 
-        rdds = {}
-        for layer_rdd in reprojected.pyramid(reprojected.zoom_level, 0):
-            rdds[layer_rdd.zoom_level] = layer_rdd
-        # self.pyramids.update({name: rdds})
-        self.pyramids[name] = rdds
+        # rdds = {}
+        # for layer_rdd in reprojected.pyramid(reprojected.zoom_level, 0):
+        #     rdds[layer_rdd.zoom_level] = layer_rdd
+        # # self.pyramids.update({name: rdds})
+        # self.pyramids[name] = rdds
 
-        if self.server_active == False:
-            t = threading.Thread(target=moop, args=(self.pyramids, self.port))
-            t.start()
-            self.server_active = True
+        # if self.server_active == False:
+        t = threading.Thread(target=moop, args=(png, # self.pyramids
+                                                self.port))
+        t.start()
+        #  self.server_active = True
 
         self.base_url = "http://localhost:8000/user/hadoop/geotrellis" # XXX
         return self.base_url + "/" + str(self.port) + "/" + name

--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -62,16 +62,21 @@ class GeoTrellis(object):
 
     def ingest(self, data, name, **kwargs):
         from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
+        from geopyspark.geotrellis.render import PngRDD
         from geopyspark.geotrellis.constants import ZOOM
 
         rdd = data.rdd
         if isinstance(rdd, RasterRDD):
             metadata = rdd.collect_metadata()
             laid_out = rdd.tile_to_layout(metadata)
-            reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
+            # reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
+            png = PngRDD.makePyramid(laid_out, data.rampname)
         elif isinstance(rdd, TiledRasterRDD):
             laid_out = rdd
-            reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
+            # reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
+            png = PngRDD.makePyramid(laid_out, data.rampname)
+        elif isinstance(rdd, PngRDD):
+            png = rdd
         else:
             raise Exception
 

--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -63,34 +63,22 @@ class GeoTrellis(object):
     def ingest(self, data, name, **kwargs):
         from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
         from geopyspark.geotrellis.render import PngRDD
-        # from geopyspark.geotrellis.constants import ZOOM
 
         rdd = data.rdd
         if isinstance(rdd, RasterRDD):
             metadata = rdd.collect_metadata()
             laid_out = rdd.tile_to_layout(metadata)
-            # reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
             png = PngRDD.makePyramid(laid_out, data.rampname)
         elif isinstance(rdd, TiledRasterRDD):
             laid_out = rdd
-            # reprojected = laid_out.reproject("EPSG:3857", scheme=ZOOM)
             png = PngRDD.makePyramid(laid_out, data.rampname)
         elif isinstance(rdd, PngRDD):
             png = rdd
         else:
-            raise Exception
+            raise TypeError("Expected a RasterRDD, TiledRasterRDD, or PngRDD")
 
-        # rdds = {}
-        # for layer_rdd in reprojected.pyramid(reprojected.zoom_level, 0):
-        #     rdds[layer_rdd.zoom_level] = layer_rdd
-        # # self.pyramids.update({name: rdds})
-        # self.pyramids[name] = rdds
-
-        # if self.server_active == False:
-        t = threading.Thread(target=moop, args=(png, # self.pyramids
-                                                self.port))
+        t = threading.Thread(target=moop, args=(png, self.port))
         t.start()
-        #  self.server_active = True
 
         self.base_url = "http://localhost:8000/user/hadoop/geotrellis" # XXX
         return self.base_url + "/" + str(self.port) + "/" + name

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -4,7 +4,7 @@ import rasterio
 import threading
 import time
 
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 
 def make_image(arr):
@@ -29,7 +29,7 @@ clamp = np.vectorize(clamp)
 alpha = np.vectorize(alpha)
 lock = threading.Lock()
 
-def moop(pyramids, port):
+def moop(png, port):
     from flask import Flask, make_response, abort
 
     app = Flask(__name__)
@@ -40,61 +40,68 @@ def moop(pyramids, port):
         return time.strftime("%H:%M:%S") + "\n"
 
 
-    @app.route("/exists/<layer_name>")
-    def exists(layer_name):
-        return str(layer_name in pyramids) + "\n"
+    # @app.route("/exists/<layer_name>")
+    # def exists(layer_name):
+    #     return str(layer_name in pyramids) + "\n"
 
-    @app.route("/remove/<layer_name>")
-    def remove(layer_name):
-        if layer_name in pyramids:
-            del pyramids[layer_name]
-            return "yes\n"
-        else:
-            return "no\n"
+    # @app.route("/remove/<layer_name>")
+    # def remove(layer_name):
+    #     if layer_name in pyramids:
+    #         del pyramids[layer_name]
+    #         return "yes\n"
+    #     else:
+    #         return "no\n"
 
     @app.route("/tile/<layer_name>/<int:x>/<int:y>/<int:zoom>.png")
     def tile(layer_name, x, y, zoom):
 
         # fetch data
         try:
-            lock.acquire()
-            pyramid = pyramids[layer_name]
-            rdd = pyramid[zoom]
-            tile = rdd.lookup(col=x, row=y)
-            arr = tile[0]['data']
+            # pyramid = pyramids[layer_name]
+            # rdd = pyramid[zoom]
+            img = png.lookup(x, y, zoom)
+            # arr = tile[0]['data']
             # nodata = -32768 #tile[0]['no_data_value']
         except:
-            arr = None
-        finally:
-            lock.release()
+            img = None
 
-        if arr == None:
-            abort(404)
+        if img == None or len(img) == 0:
+            # abort(404)
+            image = Image.new('RGBA', (256,256))
+            draw = ImageDraw.Draw(image)
+            draw.rectangle([0, 0, 255, 255], outline=(255,0,0,255))
+            draw.line([(0,0),(255,255)], fill=(255,0,0,255))
+            draw.line([(0,255),(255,0)], fill=(255,0,0,255))
+            draw.text((136,122), str(13) + ', ' + str(12), fill=(255,0,0,255))
+            del draw
+            bio = io.BytesIO()
+            image.save(bio, 'PNG')
+            img = [bio.getvalue()]
 
-        bands = arr.shape[0]
-        if bands >= 3:
-            bands = 3
-        else:
-            bands = 1
-        arrs = [np.array(arr[i, :, :]).reshape(256, 256) for i in range(bands)]
+        # bands = arr.shape[0]
+        # if bands >= 3:
+        #     bands = 3
+        # else:
+        #     bands = 1
+        # arrs = [np.array(arr[i, :, :]).reshape(256, 256) for i in range(bands)]
 
-        # create tile
-        if bands == 3:
-            images = [make_image(clamp(remap(arr))) for arr in arrs]
-            alfa = alpha(arrs[0])
-            # alfa[arrs[0] == nodata] = 0
-            images.append(make_image(alfa))
-            image = Image.merge('RGBA', images)
-        else:
-            gray = make_image(clamp(remap(arrs[0])))
-            alfa = alpha(arrs[0])
-            # alfa[arrs[0] == nodata] = 0
-            image = Image.merge('RGBA', list(gray, gray, gray, make_image(alfa)))
+        # # create tile
+        # if bands == 3:
+        #     images = [make_image(clamp(remap(arr))) for arr in arrs]
+        #     alfa = alpha(arrs[0])
+        #     # alfa[arrs[0] == nodata] = 0
+        #     images.append(make_image(alfa))
+        #     image = Image.merge('RGBA', images)
+        # else:
+        #     gray = make_image(clamp(remap(arrs[0])))
+        #     alfa = alpha(arrs[0])
+        #     # alfa[arrs[0] == nodata] = 0
+        #     image = Image.merge('RGBA', list(gray, gray, gray, make_image(alfa)))
 
         # return tile
-        bio = io.BytesIO()
-        image.save(bio, 'PNG')
-        response = make_response(bio.getvalue())
+        #bio = io.BytesIO(img[0])
+        #Image.open(bio)
+        response = make_response(img[0])
         response.headers['Content-Type'] = 'image/png'
         return response
 

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -62,6 +62,7 @@ def moop(pyramids, port):
             rdd = pyramid[zoom]
             tile = rdd.lookup(col=x, row=y)
             arr = tile[0]['data']
+            # nodata = -32768 #tile[0]['no_data_value']
         except:
             arr = None
         finally:
@@ -79,13 +80,16 @@ def moop(pyramids, port):
 
         # create tile
         if bands == 3:
-            images = [make_image(clamp(arr)) for arr in arrs]
-            images.append(make_image(alpha(arrs[0])))
+            images = [make_image(clamp(remap(arr))) for arr in arrs]
+            alfa = alpha(arrs[0])
+            # alfa[arrs[0] == nodata] = 0
+            images.append(make_image(alfa))
             image = Image.merge('RGBA', images)
         else:
-            gray = make_image(clamp(arrs[0]))
-            alfa = make_image(alpha(arrs[0]))
-            image = Image.merge('RGBA', list(gray, gray, gray, alfa))
+            gray = make_image(clamp(remap(arrs[0])))
+            alfa = alpha(arrs[0])
+            # alfa[arrs[0] == nodata] = 0
+            image = Image.merge('RGBA', list(gray, gray, gray, make_image(alfa)))
 
         # return tile
         bio = io.BytesIO()

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -6,7 +6,6 @@ import time
 
 from PIL import Image, ImageDraw, ImageFont
 
-
 def make_image(arr):
     return Image.fromarray(arr.astype('uint8')).convert('L')
 
@@ -39,68 +38,30 @@ def moop(png, port):
     def ping():
         return time.strftime("%H:%M:%S") + "\n"
 
-
-    # @app.route("/exists/<layer_name>")
-    # def exists(layer_name):
-    #     return str(layer_name in pyramids) + "\n"
-
-    # @app.route("/remove/<layer_name>")
-    # def remove(layer_name):
-    #     if layer_name in pyramids:
-    #         del pyramids[layer_name]
-    #         return "yes\n"
-    #     else:
-    #         return "no\n"
-
     @app.route("/tile/<layer_name>/<int:x>/<int:y>/<int:zoom>.png")
     def tile(layer_name, x, y, zoom):
 
         # fetch data
         try:
-            # pyramid = pyramids[layer_name]
-            # rdd = pyramid[zoom]
             img = png.lookup(x, y, zoom)
-            # arr = tile[0]['data']
-            # nodata = -32768 #tile[0]['no_data_value']
         except:
             img = None
 
         if img == None or len(img) == 0:
-            # abort(404)
-            image = Image.new('RGBA', (256,256))
-            draw = ImageDraw.Draw(image)
-            draw.rectangle([0, 0, 255, 255], outline=(255,0,0,255))
-            draw.line([(0,0),(255,255)], fill=(255,0,0,255))
-            draw.line([(0,255),(255,0)], fill=(255,0,0,255))
-            draw.text((136,122), str(13) + ', ' + str(12), fill=(255,0,0,255))
-            del draw
-            bio = io.BytesIO()
-            image.save(bio, 'PNG')
-            img = [bio.getvalue()]
+            if png.debug:
+                image = Image.new('RGBA', (256,256))
+                draw = ImageDraw.Draw(image)
+                draw.rectangle([0, 0, 255, 255], outline=(255,0,0,255))
+                draw.line([(0,0),(255,255)], fill=(255,0,0,255))
+                draw.line([(0,255),(255,0)], fill=(255,0,0,255))
+                draw.text((136,122), str(x) + ', ' + str(y) + ', ' + str(zoom), fill=(255,0,0,255))
+                del draw
+                bio = io.BytesIO()
+                image.save(bio, 'PNG')
+                img = [bio.getvalue()]
+            else:
+                abort(404)
 
-        # bands = arr.shape[0]
-        # if bands >= 3:
-        #     bands = 3
-        # else:
-        #     bands = 1
-        # arrs = [np.array(arr[i, :, :]).reshape(256, 256) for i in range(bands)]
-
-        # # create tile
-        # if bands == 3:
-        #     images = [make_image(clamp(remap(arr))) for arr in arrs]
-        #     alfa = alpha(arrs[0])
-        #     # alfa[arrs[0] == nodata] = 0
-        #     images.append(make_image(alfa))
-        #     image = Image.merge('RGBA', images)
-        # else:
-        #     gray = make_image(clamp(remap(arrs[0])))
-        #     alfa = alpha(arrs[0])
-        #     # alfa[arrs[0] == nodata] = 0
-        #     image = Image.merge('RGBA', list(gray, gray, gray, make_image(alfa)))
-
-        # return tile
-        #bio = io.BytesIO(img[0])
-        #Image.open(bio)
         response = make_response(img[0])
         response.headers['Content-Type'] = 'image/png'
         return response

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -11,21 +11,19 @@ from shapely.geometry import Polygon
 
 class RddRasterData(object):
 
-    def __init__(self, rdd, name=None, remapper=None):
+    def __init__(self, rdd, name=None, rampname="Viridis"):
         from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
+        from geopyspark.geotrellis.render import PngRDD
 
-        if not (isinstance(rdd, RasterRDD) or isinstance(rdd, TiledRasterRDD)):
+        if not (isinstance(rdd, RasterRDD) or isinstance(rdd, TiledRasterRDD)) or isinstance(rdd, PngRDD):
             raise Exception
 
         self.rdd = rdd
 
-        if not remapper:
-            self.remapper = lambda x: x
-        else:
-            self.remapper = remapper
+        self.rampname = rampname
 
         if not name:
-            self.name = str(abs(hash(rdd) + hash(remapper)))
+            self.name = str(abs(hash(rdd) + hash(rampname)))
         else:
             self.name = name
 

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -15,7 +15,7 @@ class RddRasterData(object):
         from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
         from geopyspark.geotrellis.render import PngRDD
 
-        if not (isinstance(rdd, RasterRDD) or isinstance(rdd, TiledRasterRDD)) or isinstance(rdd, PngRDD):
+        if not (isinstance(rdd, RasterRDD) or isinstance(rdd, TiledRasterRDD) or isinstance(rdd, PngRDD)):
             raise Exception
 
         self.rdd = rdd

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -16,7 +16,7 @@ class RddRasterData(object):
         from geopyspark.geotrellis.render import PngRDD
 
         if not (isinstance(rdd, RasterRDD) or isinstance(rdd, TiledRasterRDD) or isinstance(rdd, PngRDD)):
-            raise Exception
+            raise TypeError("Expected a RasterRDD, TiledRasterRDD, or PngRDD")
 
         self.rdd = rdd
 


### PR DESCRIPTION
This PR uses GeoPySpark's PngRDD to display tiles directly as PNGs, delegating rendering decisions to the client.  See https://github.com/locationtech-labs/geopyspark/pull/181 for more details.